### PR TITLE
Nix : Add initial support nix develop

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,16 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # C source files use Linux kernel style
-[*.c]
-intent_style = tab
+[*.[ch]]
+indent_style = tab
+indent_size = 8
+trim_trailing_whitespace = true
+
+[*.sym]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# try to use flake initially, fallback to non-flake use otherwise
+if nix flake show &> /dev/null; then
+  use flake
+else
+  use nix
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 *.exe
 *.out
 *.app
+
+#nix and direnv
+.direnv/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2020-2023 Eelco Dolstra and the flake-compat contributors
+#
+# SPDX-License-Identifier: MIT
+# This file originates from:
+# https://github.com/nix-community/flake-compat
+# This file provides backward compatibility to nix < 2.4 clients
+{system ? builtins.currentSystem}: let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat {
+    inherit system;
+    src = ./.;
+  };
+in
+  flake.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,118 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688025799,
+        "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "8bf105319d44f6b9f0d764efa4fdef9f1cc9ba1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1692742795,
+        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699781429,
+        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1699786194,
+        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "Open-TEE - GP emulator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-root.url = "github:srid/flake-root";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    # For preserving compatibility with non-Flake users
+    flake-compat = {
+      url = "github:nix-community/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake
+    {
+      inherit inputs;
+    } {
+      systems = [
+        "x86_64-linux"
+        #"aarch64-linux"
+      ];
+      imports = [
+        ./nix
+      ];
+    };
+}
+#     let
+#       # to work with older version of flakes
+#       lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+#       # Generate a user-friendly version number.
+#       version = builtins.substring 0 8 lastModifiedDate;
+#       # System types to support.
+#       supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+#       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+#       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+#       # Nixpkgs instantiated for supported system types.
+#       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });
+#     in
+#     {
+#       # A Nixpkgs overlay.
+#       overlay = final: prev: {
+#         hello = with final; stdenv.mkDerivation rec {
+#           pname = "hello";
+#           inherit version;
+#           src = ./.;
+#           nativeBuildInputs = [ autoreconfHook ];
+#         };
+#       };
+#       # Provide some binary packages for selected system types.
+#       packages = forAllSystems (system:
+#         {
+#           inherit (nixpkgsFor.${system}) hello;
+#         });
+#       # The default package for 'nix build'. This makes sense if the
+#       # flake provides only one package or there is a clear "main"
+#       # package.
+#       defaultPackage = forAllSystems (system: self.packages.${system}.hello);
+#       # A NixOS module, if applicable (e.g. if the package provides a system service).
+#       nixosModules.hello =
+#         { pkgs, ... }:
+#         {
+#           nixpkgs.overlays = [ self.overlay ];
+#           environment.systemPackages = [ pkgs.hello ];
+#           #systemd.services = { ... };
+#         };
+#       # Tests run by 'nix flake check' and by Hydra.
+#       checks = forAllSystems
+#         (system:
+#           with nixpkgsFor.${system};
+#           {
+#             inherit (self.packages.${system}) hello;
+#             # Additional tests, if applicable.
+#             test = stdenv.mkDerivation {
+#               pname = "hello-test";
+#               inherit version;
+#               buildInputs = [ hello ];
+#               dontUnpack = true;
+#               buildPhase = ''
+#                 echo 'running some integration tests'
+#                 [[ $(hello) = 'Hello Nixers!' ]]
+#               '';
+#               installPhase = "mkdir -p $out";
+#             };
+#           }
+#           // lib.optionalAttrs stdenv.isLinux {
+#             # A VM test of the NixOS module.
+#             vmTest =
+#               with import (nixpkgs + "/nixos/lib/testing-python.nix") {
+#                 inherit system;
+#               };
+#               makeTest {
+#                 nodes = {
+#                   client = { ... }: {
+#                     imports = [ self.nixosModules.hello ];
+#                   };
+#                 };
+#                 testScript =
+#                   ''
+#                     start_all()
+#                     client.wait_for_unit("multi-user.target")
+#                     client.succeed("hello")
+#                   '';
+#               };
+#           }
+#         );
+#     };
+# }

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  # perSystem = {self', ...}: {
+
+  # };
+}

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{lib, ...}: {
+  perSystem = {
+    self',
+    pkgs,
+    ...
+  }: {
+    checks =
+      {
+        # checks that copyright headers are compliant
+        # todo this could be moved into a shared flake
+        reuse =
+          pkgs.runCommandLocal "reuse-lint" {
+            nativeBuildInputs = [pkgs.reuse];
+          } ''
+            cd ${../.}
+            reuse lint
+            touch $out
+          '';
+      }
+      //
+      # merge in the package derivations to force a build of all packages during a `nix flake check`
+      (with lib; mapAttrs' (n: nameValuePair "package-${n}") self'.packages);
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+#    ./apps.nix
+    ./checks.nix
+    ./devshell.nix
+#    ./packages.nix
+    ./treefmt.nix
+  ];
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  perSystem = {
+    pkgs,
+    self',
+    ...
+  }: {
+    devShells.default = pkgs.mkShell rec {
+      name = "OpenTEE-dev-shell";
+
+      packages = with pkgs; [
+        autoreconfHook
+        coreutils
+        curl
+        fuse
+        fuse-common
+        gnugrep
+        gnused
+        gzip
+        libelf
+        mbedtls
+        nix
+        pkg-config
+        ripgrep-all
+        zlib
+      ];
+
+      shellHook = ''
+      '';
+    };
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+# {inputs, ...}:
+{
+  #   perSystem = {
+  #     pkgs,
+  #     lib,
+  #     ...
+  #   }: {
+  #   };
+}

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{inputs, ...}: {
+  imports = with inputs; [
+    flake-root.flakeModule
+    treefmt-nix.flakeModule
+  ];
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: {
+    treefmt.config = {
+      package = pkgs.treefmt;
+      inherit (config.flake-root) projectRootFile;
+
+      programs = {
+        alejandra.enable = true; # nix formatter https://github.com/kamadorueda/alejandra
+        deadnix.enable = true; # removes dead nix code https://github.com/astro/deadnix
+        shellcheck.enable = true; # lints shell scripts https://github.com/koalaman/shellcheck
+        statix.enable = true; # prevents use of nix anti-patterns https://github.com/nerdypepper/statix
+        clang-format.enable = true;
+      };
+    };
+
+    # configures treefmt as the program to use when invoke `nix fmt`
+    formatter = config.treefmt.build.wrapper;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2020-2023 Eelco Dolstra and the flake-compat contributors
+#
+# SPDX-License-Identifier: MIT
+# This file originates from:
+# https://github.com/nix-community/flake-compat
+# This file provides backward compatibility to nix < 2.4 clients
+{system ? builtins.currentSystem}: let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat {
+    inherit system;
+    src = ./.;
+  };
+in
+  flake.shellNix


### PR DESCRIPTION
Initial work in supporting Nix packaging. It introduces a devshell for getting started in development on Nix based environments.

In addition an direnv is defined to make it easy to transition into the development environment. There are 3 supported ways:

With Flakes enabled on your host
`nix develop`

Without flakes support
`nix-shell`

With direnv enabled
`direnv allow`

And then build in the normal way.